### PR TITLE
MC-20: Implement generic route option and route list component

### DIFF
--- a/src/components/RouteOption/DockedEbikeRouteOption.jsx
+++ b/src/components/RouteOption/DockedEbikeRouteOption.jsx
@@ -53,6 +53,8 @@ DockedEbikeRouteOption.propTypes = {
   onDockingStationChange: PropTypes.func.isRequired,
 };
 
+DockedEbikeRouteOption.TYPE = "docked-ebike";
+
 function DockingStationSelector({ label, value, options, onChange, style }) {
   return (
     <div style={style}>

--- a/src/components/RouteOption/RouteOption.jsx
+++ b/src/components/RouteOption/RouteOption.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+import PropTypes from "prop-types";
+import DockedEbikeRouteOption from "./DockedEbikeRouteOption";
+
+export default function RouteOption({type, ...props}) {
+  if (type === DockedEbikeRouteOption.TYPE) {
+    return DockedEbikeRouteOption(props);
+  } else {
+    throw TypeError(`Unknown route option type: '${type}'.`);
+  }
+}
+
+RouteOption.propTypes = {
+  type: PropTypes.oneOf([
+    DockedEbikeRouteOption.TYPE,
+  ]),
+}

--- a/src/components/RouteOption/RouteOption.stories.js
+++ b/src/components/RouteOption/RouteOption.stories.js
@@ -1,14 +1,15 @@
-import DockedEbikeRouteOption from "./DockedEbikeRouteOption";
+import RouteOption from "./RouteOption";
 import { fn } from "@storybook/test";
 
 export default {
   title: "Components/RouteOption",
-  component: DockedEbikeRouteOption,
+  component: RouteOption,
   tags: ["autodocs"],
 };
 
-export const Default = {
+export const DockedEbike = {
   args: {
+    type: "docked-ebike",
     provider: { name: "Some provider" },
     fromDockingStations: [
       { value: "foo", label: "Foo street, 123" },
@@ -20,8 +21,9 @@ export const Default = {
   },
 };
 
-export const Empty = {
+export const DockedEbikeEmpty = {
   args: {
+    type: "docked-ebike",
     provider: { name: "Some provider" },
     fromDockingStations: [],
     toDockingStations: [],

--- a/src/components/RouteOptionList/RouteOptionList.jsx
+++ b/src/components/RouteOptionList/RouteOptionList.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import PropTypes from "prop-types";
+import RouteOption from "../RouteOption/RouteOption";
+
+export default function RouteOptionList({routeOptionProps}) {
+  return (
+    <div>
+      {routeOptionProps.map(props => RouteOption(props))}
+    </div>
+  );
+}
+
+RouteOptionList.propTypes = {
+  routeOptionProps: PropTypes.arrayOf(RouteOption.propTypes),
+}

--- a/src/components/RouteOptionList/RouteOptionList.stories.js
+++ b/src/components/RouteOptionList/RouteOptionList.stories.js
@@ -1,0 +1,37 @@
+import RouteOptionList from "./RouteOptionList";
+import {fn} from "@storybook/test";
+
+export default {
+  title: "Components/RouteOptionList",
+  component: RouteOptionList,
+  tags: ["autodocs"],
+};
+
+export const Default = {
+  args: {
+    routeOptionProps: [
+      {
+        type: "docked-ebike",
+        provider: { name: "Some provider" },
+        fromDockingStations: [
+          { value: "foo", label: "Foo street, 123" },
+          { value: "bar", label: "Bar street, 123" },
+          { value: "baz", label: "Baz street, 123" },
+        ],
+        toDockingStations: [{ value: "qux", label: "Qux street, 123" }],
+        onDockingStationChange: fn(),
+      },
+      {
+        type: "docked-ebike",
+        provider: { name: "Other provider" },
+        fromDockingStations: [
+          { value: "lorem", label: "Lorem street, 123" },
+          { value: "ipsum", label: "Ipsum street, 123" },
+          { value: "dolor", label: "Dolor street, 123" },
+        ],
+        toDockingStations: [{ value: "et", label: "Et street, 123" }],
+        onDockingStationChange: fn(),
+      }
+    ],
+  },
+};


### PR DESCRIPTION
# Description
This pull request proposes to add a generic route option component that serves as a factory to create specialized components, for example, a docked e-bike route option card. Moreover, it adds a route option list component, takes a list of route option properties and renders them as a list from top to down. 

# Screenshots
_Docked e-bike option story implemented in terms of generic route option_
<img width="1403" alt="image" src="https://github.com/user-attachments/assets/ea3b02f0-bab5-4e7b-b6ce-ca46f4bf5c29">

_Route list story_
<img width="1401" alt="image" src="https://github.com/user-attachments/assets/053625a4-88ae-49b5-acc9-a774824e9a9b">
