### PR TITLE
MC-24: Render docked ebike routes on map 'as the crow flies'

### DIFF
--- a/gatsby-browser.jsx
+++ b/gatsby-browser.jsx
@@ -1,0 +1,5 @@
+const {configureLeaflet} = require("./src/lib/leaflet");
+
+exports.onInitialClientRender = function() {
+  configureLeaflet();
+}

--- a/src/components/RouteMap/DockedEbikeRouteMapFragment.jsx
+++ b/src/components/RouteMap/DockedEbikeRouteMapFragment.jsx
@@ -1,0 +1,31 @@
+import {DockedEbikeRoutePropType} from "../../lib/route";
+import {Marker, useMap} from "react-leaflet";
+import React from "react";
+import L from "leaflet";
+
+export default function DockedEbikeRouteMapFragment({route}) {
+  const coordinates = [
+    route.startingPoint,
+    route.startingPointDockingStation,
+    route.destinationDockingStation,
+    route.destination,
+  ];
+
+  const map = useMap();
+  map.fitBounds(new L.LatLngBounds(coordinates), {padding: [25, 25]});
+  L.polyline(coordinates).addTo(map)
+
+  return (
+    <>
+      <Marker position={[51.505, -0.09]}/>
+      <Marker position={route.startingPoint}/>
+      <Marker position={route.startingPointDockingStation}/>
+      <Marker position={route.destinationDockingStation}/>
+      <Marker position={route.destination}/>
+    </>
+  );
+}
+
+DockedEbikeRouteMapFragment.propTypes = {
+  route: DockedEbikeRoutePropType.isRequired,
+};

--- a/src/components/RouteMap/RouteMap.jsx
+++ b/src/components/RouteMap/RouteMap.jsx
@@ -1,9 +1,11 @@
 import React from "react";
-import {MapContainer, Marker, TileLayer} from "react-leaflet";
+import {MapContainer, TileLayer} from "react-leaflet";
 import "leaflet/dist/leaflet.css"
 import {isDomAvailable} from "../../lib/util";
+import {RoutePropType} from "../../lib/route";
+import DockedEbikeRouteMapFragment from "./DockedEbikeRouteMapFragment";
 
-export default function RouteMap() {
+export default function RouteMap(props) {
   if (!isDomAvailable()) {
     return <div>Loading...</div>;
   }
@@ -14,7 +16,23 @@ export default function RouteMap() {
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
       />
-      <Marker position={[51.505, -0.09]}/>
+      {props.route && <RouteMapFragment {...props} />}
     </MapContainer>
   )
 }
+
+function RouteMapFragment(props) {
+  if (props.route.type === "docked-ebike") {
+    return <DockedEbikeRouteMapFragment {...props} />
+  } else {
+    throw TypeError(`Unknown route type: '${props.route.type}'.`);
+  }
+}
+
+RouteMapFragment.propTypes = {
+  route: RoutePropType.isRequired,
+}
+
+RouteMap.propTypes = {
+  route: RoutePropType,
+};

--- a/src/components/RouteMap/RouteMap.jsx
+++ b/src/components/RouteMap/RouteMap.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {MapContainer, TileLayer} from "react-leaflet";
+import {MapContainer, Marker, TileLayer} from "react-leaflet";
 import "leaflet/dist/leaflet.css"
 import {isDomAvailable} from "../../lib/util";
 
@@ -14,6 +14,7 @@ export default function RouteMap() {
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
       />
+      <Marker position={[51.505, -0.09]}/>
     </MapContainer>
   )
 }

--- a/src/components/RouteMap/RouteMap.stories.js
+++ b/src/components/RouteMap/RouteMap.stories.js
@@ -10,3 +10,15 @@ export const Default = {
   args: {
   }
 }
+
+export const DockedEbike = {
+  args: {
+    route: {
+      type: "docked-ebike",
+      startingPoint: [41.40624877362421, 2.159413247558875],
+      startingPointDockingStation: [41.40568486276983, 2.1624520213408296],
+      destinationDockingStation: [41.38511382647192, 2.1431890499002897],
+      destination: [41.38413627190235, 2.145163260838563],
+    }
+  }
+}

--- a/src/lib/leaflet.js
+++ b/src/lib/leaflet.js
@@ -1,0 +1,10 @@
+/** Source: https://github.com/colbyfayock/gatsby-starter-leaflet/blob/master/src/hooks/useConfigureLeaflet.js */
+export function configureLeaflet() {
+  const L = require("leaflet");
+  delete L.Icon.Default.prototype._getIconUrl;
+  L.Icon.Default.mergeOptions({
+    iconRetinaUrl: require('leaflet/dist/images/marker-icon-2x.png').default,
+    iconUrl: require('leaflet/dist/images/marker-icon.png').default,
+    shadowUrl: require('leaflet/dist/images/marker-shadow.png').default,
+  });
+}

--- a/src/lib/route.js
+++ b/src/lib/route.js
@@ -1,0 +1,18 @@
+import PropTypes from "prop-types";
+
+export const CoordinatesPropType = PropTypes.shape({
+  longitude: PropTypes.number.isRequired,
+  latitude: PropTypes.number.isRequired,
+});
+
+export const DockedEbikeRoutePropType = PropTypes.shape({
+  type: "docked-ebike",
+  startingPoint: CoordinatesPropType.isRequired,
+  destination: CoordinatesPropType.isRequired,
+  startingPointDockingStation: CoordinatesPropType.isRequired,
+  destinationDockingStation: CoordinatesPropType.isRequired,
+});
+
+export const RoutePropType = PropTypes.oneOfType([
+  DockedEbikeRoutePropType,
+]);


### PR DESCRIPTION
# Change list
- Implement simple docked ebike route map 'as the crow flies' - route rendered with markers and lines
- Configure Leaflet to fix default Leaflet marker icons not found error (known leaflet bug)

# Screenshot
<img width="1605" alt="image" src="https://github.com/user-attachments/assets/bcf6f7cc-124d-4426-a35b-bb13e5ad9276">
