### PR TITLE
MC-22: Fix LocationInput querying on result selection

### DIFF
--- a/src/components/LocationInput/LocationInput.jsx
+++ b/src/components/LocationInput/LocationInput.jsx
@@ -8,6 +8,7 @@ import PropTypes from "prop-types";
 export default function LocationInput({onLocationChange, searchDelayMillis}) {
   const [address, setAddress] = useState('');
   const [results, setResults] = useState([]);
+  const [focus, setFocus] = useState(false);
   const provider = new OpenStreetMapProvider();
 
   const handleTextInputChange = (event) => {
@@ -15,9 +16,11 @@ export default function LocationInput({onLocationChange, searchDelayMillis}) {
   };
 
   useEffect(() => {
-    const func = setTimeout(searchAddress, searchDelayMillis);
-    return () => clearTimeout(func)
-  }, [address])
+    if (focus && address) {
+      const func = setTimeout(searchAddress, searchDelayMillis);
+      return () => clearTimeout(func);
+    }
+  }, [focus, address])
 
   function searchAddress() {
     provider
@@ -39,6 +42,8 @@ export default function LocationInput({onLocationChange, searchDelayMillis}) {
         placeholder="Enter address"
         value={address}
         onChange={handleTextInputChange}
+        onBlur={() => setFocus(false)}
+        onFocus={() => setFocus(true)}
       />
       {results.length > 0 && (
         <ol style={{display: "block"}}>


### PR DESCRIPTION
The location input has a bug that causes it to query for addresses after selecting an address. So, what happens is:
1. User fills in a query term into the location input.
2. UI shows a list of search results.
3. User clicks on one of the results.
4. UI clears the list of suggestions and sets the selected result.
5. UI detects the programmatic change and sends out another request.
6. UI fills in the list of suggestions, even though the user has already selected a result. 🐛

This pull request fixes this by only querying for locations when the input is in focus, i.e., when the user is typing.