### PR TITLE
MC-21: Add 'plan a route' page layout with story components

### DIFF
--- a/gatsby-browser.jsx
+++ b/gatsby-browser.jsx
@@ -1,5 +1,7 @@
 const {configureLeaflet} = require("./src/lib/leaflet");
 
+require("./src/styles/reset.css")
+
 exports.onInitialClientRender = function() {
   configureLeaflet();
 }

--- a/src/components/LocationInput/LocationInput.jsx
+++ b/src/components/LocationInput/LocationInput.jsx
@@ -1,11 +1,17 @@
 import React, {useEffect, useState} from 'react';
-import { OpenStreetMapProvider } from 'leaflet-geosearch';
 
 import 'leaflet/dist/leaflet.css';
 import 'leaflet-geosearch/dist/geosearch.css';
 import PropTypes from "prop-types";
+import {OpenStreetMapProvider} from "leaflet-geosearch";
+import {isDomAvailable} from "../../lib/util";
 
 export default function LocationInput({onLocationChange, searchDelayMillis}) {
+  if (!isDomAvailable()) {
+    // Leaflet-geosearch not available with SSR
+    return <></>;
+  }
+
   const [address, setAddress] = useState('');
   const [results, setResults] = useState([]);
   const [focus, setFocus] = useState(false);

--- a/src/components/RouteInputForm/RouteInputForm.jsx
+++ b/src/components/RouteInputForm/RouteInputForm.jsx
@@ -23,4 +23,3 @@ RouteInputForm.propTypes = {
 }
 
 export default RouteInputForm;
-

--- a/src/components/RouteMap/RouteMap.jsx
+++ b/src/components/RouteMap/RouteMap.jsx
@@ -4,6 +4,7 @@ import "leaflet/dist/leaflet.css"
 import {isDomAvailable} from "../../lib/util";
 import {RoutePropType} from "../../lib/route";
 import DockedEbikeRouteMapFragment from "./DockedEbikeRouteMapFragment";
+import Style from "react-style-proptype";
 
 export default function RouteMap(props) {
   if (!isDomAvailable()) {
@@ -11,7 +12,7 @@ export default function RouteMap(props) {
   }
 
   return (
-    <MapContainer style={{ height: "400px" }} center={[51.505, -0.09]} zoom={13} scrollWheelZoom={false}>
+    <MapContainer style={props.style} center={[51.505, -0.09]} zoom={13} scrollWheelZoom={false}>
       <TileLayer
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
@@ -35,4 +36,11 @@ RouteMapFragment.propTypes = {
 
 RouteMap.propTypes = {
   route: RoutePropType,
+  style: Style,
+};
+
+RouteMap.defaultProps = {
+  style: {
+    height: "400px",
+  }
 };

--- a/src/pages/plan-a-route.js
+++ b/src/pages/plan-a-route.js
@@ -1,0 +1,19 @@
+import React from "react"
+import RouteMap from "../components/RouteMap/RouteMap";
+import RouteInputForm from "../components/RouteInputForm/RouteInputForm";
+import RouteOptionList from "../components/RouteOptionList/RouteOptionList";
+import {fn} from "@storybook/test";
+import {Default as RouteOptionListStory} from "../components/RouteOptionList/RouteOptionList.stories";
+import {DockedEbike as RouteMapStory} from "../components/RouteMap/RouteMap.stories";
+
+export default function PlanARoutePage() {
+  return (
+    <main style={{ height: "100vh"}}>
+      <aside style={{width: "350px", float: "left"}}>
+        <RouteInputForm onStartingPointChange={fn()} onDestinationChange={fn()}/>
+        <RouteOptionList routeOptionProps={RouteOptionListStory.args.routeOptionProps} />
+      </aside>
+      <RouteMap style={{ height: "100%" }} route={RouteMapStory.args.route}/>
+    </main>
+  )
+};

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -1,0 +1,48 @@
+/* http://meyerweb.com/eric/tools/css/reset/
+   v2.0 | 20110126
+   License: none (public domain)
+*/
+
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+    display: block;
+}
+body {
+    line-height: 1;
+}
+ol, ul {
+    list-style: none;
+}
+blockquote, q {
+    quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+    content: '';
+    content: none;
+}
+table {
+    border-collapse: collapse;
+    border-spacing: 0;
+}


### PR DESCRIPTION
# Description
This pull request adds a /plan-a-route page with a basic page layout. As all the "real" components are ready at this point, this pull request uses the real components already as placeholders in this layout, but with dummy data.

# Changelist
* Add a /plan-a-route page with a basic page layout
* Add a DOM check to LocationInput to prevent it from loading in SSR - otherwise, the build fails
* Add CSS reset so that 100vh equals 100% height - https://meyerweb.com/eric/tools/css/reset/

# Screenshot
![image](https://github.com/user-attachments/assets/3e5f5824-70c7-4292-9850-865ac6323d23)
