### PR TITLE
MC-26: Populate route options with data from backend

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -8,6 +8,7 @@ const config = {
     "@storybook/addon-essentials",
     "@chromatic-com/storybook",
     "@storybook/addon-interactions",
+    "storybook-addon-apollo-client",
   ],
   framework: {
     name: "@storybook/react-webpack5",

--- a/gatsby-browser.jsx
+++ b/gatsby-browser.jsx
@@ -1,7 +1,12 @@
 const {configureLeaflet} = require("./src/lib/leaflet");
+const {wrapWithApolloProvider} = require("./src/lib/apollo");
 
 require("./src/styles/reset.css")
 
 exports.onInitialClientRender = function() {
   configureLeaflet();
+}
+
+exports.wrapRootElement = function({element}) {
+  return wrapWithApolloProvider(element);
 }

--- a/gatsby-ssr.jsx
+++ b/gatsby-ssr.jsx
@@ -1,0 +1,5 @@
+const {wrapWithApolloProvider} = require("./src/lib/apollo");
+
+exports.wrapRootElement = function({element}) {
+  return wrapWithApolloProvider(element);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,13 @@
       "name": "micro-commute",
       "version": "1.0.0",
       "dependencies": {
+        "@apollo/client": "^3.11.4",
         "@esri/react-arcgis": "^5.2.0",
         "esri-leaflet": "^3.0.12",
         "esri-leaflet-geocoder": "^3.1.4",
         "gatsby": "^5.13.5",
         "gatsby-plugin-sass": "^6.13.1",
+        "graphql": "^16.9.0",
         "leaflet": "^1.9.4",
         "leaflet-geosearch": "^4.0.0",
         "react": "^18.3.1",
@@ -33,7 +35,8 @@
         "@storybook/test": "^8.2.2",
         "prop-types": "^15.8.1",
         "react-style-proptype": "^3.2.2",
-        "storybook": "^8.2.2"
+        "storybook": "^8.2.2",
+        "storybook-addon-apollo-client": "^7.3.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -52,6 +55,49 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@apollo/client": {
+      "version": "3.11.4",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.11.4.tgz",
+      "integrity": "sha512-bmgYKkULpym8wt8aXlAZ1heaYo0skLJ5ru0qJ+JCRoo03Pe+yIDbBCnqlDw6Mjj76hFkDw3HwFMgZC2Hxp30Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/caches": "^1.0.0",
+        "@wry/equality": "^0.5.6",
+        "@wry/trie": "^0.5.0",
+        "graphql-tag": "^2.12.6",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.18.0",
+        "prop-types": "^15.7.2",
+        "rehackt": "^0.1.0",
+        "response-iterator": "^0.2.6",
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.10.3",
+        "tslib": "^2.3.0",
+        "zen-observable-ts": "^1.2.5"
+      },
+      "peerDependencies": {
+        "graphql": "^15.0.0 || ^16.0.0",
+        "graphql-ws": "^5.5.5",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0",
+        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ardatan/relay-compiler": {
@@ -6854,6 +6900,54 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "node_modules/@wry/caches": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
+      "integrity": "sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/context": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz",
+      "integrity": "sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/equality": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
+      "integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/trie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
+      "integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -12575,9 +12669,10 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
     },
     "node_modules/graphql": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.0.tgz",
-      "integrity": "sha512-0oKGaR+y3qcS5mCu1vb7KG+a89vjn06C7Ihq/dDl3jA+A8B3TKomvi3CiEcVLJQGalbu8F52LxkOym7U5sSfbg==",
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.9.0.tgz",
+      "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==",
+      "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -12804,6 +12899,15 @@
       "dependencies": {
         "capital-case": "^1.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -15264,6 +15368,30 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/optimism": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.0.tgz",
+      "integrity": "sha512-tGn8+REwLRNFnb9WmcY5IfpOqeX2kpaYJ1s6Ae3mn12AeydLkR3j+jSCmVQFoXqU8D41PAJ1RG1rCRNWmNZVmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@wry/caches": "^1.0.0",
+        "@wry/context": "^0.7.0",
+        "@wry/trie": "^0.4.3",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/optimism/node_modules/@wry/trie": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.4.3.tgz",
+      "integrity": "sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -17369,6 +17497,24 @@
         "jsesc": "bin/jsesc"
       }
     },
+    "node_modules/rehackt": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.1.0.tgz",
+      "integrity": "sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/rehype-external-links": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
@@ -17723,6 +17869,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/response-iterator": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.6.tgz",
+      "integrity": "sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/responselike": {
@@ -18596,6 +18751,16 @@
         "url": "https://opencollective.com/storybook"
       }
     },
+    "node_modules/storybook-addon-apollo-client": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/storybook-addon-apollo-client/-/storybook-addon-apollo-client-7.3.0.tgz",
+      "integrity": "sha512-Lqp9dn9sy6LdfS4e/Dx6M7cNXXLAiHBT2LKEWynxEkrMen/sgBPRUqQz0cJiLsSVbJLKov4KzWf5359UQaPxRA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@apollo/client": "^3.0.0"
+      }
+    },
     "node_modules/storybook/node_modules/commander": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
@@ -18930,6 +19095,15 @@
       "integrity": "sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==",
       "dependencies": {
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/symbol-observable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/system-architecture": {
@@ -19399,6 +19573,18 @@
       "dev": true,
       "engines": {
         "node": ">=6.10"
+      }
+    },
+    "node_modules/ts-invariant": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
+      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -20558,6 +20744,21 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
+      "license": "MIT"
+    },
+    "node_modules/zen-observable-ts": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
+      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "zen-observable": "0.8.15"
+      }
     }
   },
   "dependencies": {
@@ -20574,6 +20775,27 @@
       "requires": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@apollo/client": {
+      "version": "3.11.4",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.11.4.tgz",
+      "integrity": "sha512-bmgYKkULpym8wt8aXlAZ1heaYo0skLJ5ru0qJ+JCRoo03Pe+yIDbBCnqlDw6Mjj76hFkDw3HwFMgZC2Hxp30Mg==",
+      "requires": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/caches": "^1.0.0",
+        "@wry/equality": "^0.5.6",
+        "@wry/trie": "^0.5.0",
+        "graphql-tag": "^2.12.6",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.18.0",
+        "prop-types": "^15.7.2",
+        "rehackt": "^0.1.0",
+        "response-iterator": "^0.2.6",
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.10.3",
+        "tslib": "^2.3.0",
+        "zen-observable-ts": "^1.2.5"
       }
     },
     "@ardatan/relay-compiler": {
@@ -25215,6 +25437,38 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@wry/caches": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
+      "integrity": "sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@wry/context": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz",
+      "integrity": "sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@wry/equality": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
+      "integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@wry/trie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
+      "integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -29436,9 +29690,9 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
     },
     "graphql": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.0.tgz",
-      "integrity": "sha512-0oKGaR+y3qcS5mCu1vb7KG+a89vjn06C7Ihq/dDl3jA+A8B3TKomvi3CiEcVLJQGalbu8F52LxkOym7U5sSfbg=="
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.9.0.tgz",
+      "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw=="
     },
     "graphql-compose": {
       "version": "9.0.10",
@@ -29588,6 +29842,14 @@
       "requires": {
         "capital-case": "^1.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
       }
     },
     "hosted-git-info": {
@@ -31364,6 +31626,27 @@
       "resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.7.tgz",
       "integrity": "sha512-vz9iS7MJ5+Bp1URw8Khvdyw1H/hGvzHWlKQ7eRrQojSCDL1/SrWfrY9QebLw97n2deyRtzHRC3MkQfVNUCo91Q=="
     },
+    "optimism": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.0.tgz",
+      "integrity": "sha512-tGn8+REwLRNFnb9WmcY5IfpOqeX2kpaYJ1s6Ae3mn12AeydLkR3j+jSCmVQFoXqU8D41PAJ1RG1rCRNWmNZVmQ==",
+      "requires": {
+        "@wry/caches": "^1.0.0",
+        "@wry/context": "^0.7.0",
+        "@wry/trie": "^0.4.3",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@wry/trie": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.4.3.tgz",
+          "integrity": "sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        }
+      }
+    },
     "optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -32849,6 +33132,12 @@
         }
       }
     },
+    "rehackt": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.1.0.tgz",
+      "integrity": "sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==",
+      "requires": {}
+    },
     "rehype-external-links": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
@@ -33113,6 +33402,11 @@
           }
         }
       }
+    },
+    "response-iterator": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.6.tgz",
+      "integrity": "sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw=="
     },
     "responselike": {
       "version": "2.0.1",
@@ -33787,6 +34081,13 @@
         }
       }
     },
+    "storybook-addon-apollo-client": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/storybook-addon-apollo-client/-/storybook-addon-apollo-client-7.3.0.tgz",
+      "integrity": "sha512-Lqp9dn9sy6LdfS4e/Dx6M7cNXXLAiHBT2LKEWynxEkrMen/sgBPRUqQz0cJiLsSVbJLKov4KzWf5359UQaPxRA==",
+      "dev": true,
+      "requires": {}
+    },
     "streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
@@ -33996,6 +34297,11 @@
       "requires": {
         "tslib": "^2.0.3"
       }
+    },
+    "symbol-observable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ=="
     },
     "system-architecture": {
       "version": "0.1.0",
@@ -34340,6 +34646,14 @@
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
       "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
       "dev": true
+    },
+    "ts-invariant": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
+      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
     },
     "tsconfig-paths": {
       "version": "3.14.1",
@@ -35192,6 +35506,19 @@
             "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
+    },
+    "zen-observable-ts": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
+      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
+      "requires": {
+        "zen-observable": "0.8.15"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,11 +17,13 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@apollo/client": "^3.11.4",
     "@esri/react-arcgis": "^5.2.0",
     "esri-leaflet": "^3.0.12",
     "esri-leaflet-geocoder": "^3.1.4",
     "gatsby": "^5.13.5",
     "gatsby-plugin-sass": "^6.13.1",
+    "graphql": "^16.9.0",
     "leaflet": "^1.9.4",
     "leaflet-geosearch": "^4.0.0",
     "react": "^18.3.1",
@@ -42,6 +44,7 @@
     "@storybook/test": "^8.2.2",
     "prop-types": "^15.8.1",
     "react-style-proptype": "^3.2.2",
-    "storybook": "^8.2.2"
+    "storybook": "^8.2.2",
+    "storybook-addon-apollo-client": "^7.3.0"
   }
 }

--- a/src/components/LocationInput/LocationInput.jsx
+++ b/src/components/LocationInput/LocationInput.jsx
@@ -38,7 +38,7 @@ export default function LocationInput({onLocationChange, searchDelayMillis}) {
     const { x, y, label } = result;
     setResults([]);
     setAddress(label);
-    onLocationChange({ address: label, coordinates: { lat: y, lng: x } });
+    onLocationChange({ address: label, coordinates: { latitude: y, longitude: x } });
   };
 
   return (

--- a/src/components/RouteOptionList/RouteOptionList.jsx
+++ b/src/components/RouteOptionList/RouteOptionList.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import RouteOption from "../RouteOption/RouteOption";
 
 export default function RouteOptionList({routeOptionProps, onRouteOptionSelected}) {
-  const [selectedIndex, setSelectedIndex] = useState(null);
+  const [selectedIndex, setSelectedIndex] = useState(0);
 
   const handleOptionClick = (index, provider, routeType) => {
     setSelectedIndex(index);

--- a/src/lib/apollo.js
+++ b/src/lib/apollo.js
@@ -1,0 +1,11 @@
+import React from "react";
+import {ApolloClient, ApolloProvider, InMemoryCache} from "@apollo/client";
+
+export function wrapWithApolloProvider(element) {
+  const client = new ApolloClient({
+    uri: "https://micro-commute-backend.onrender.com/graphql",
+    cache: new InMemoryCache(),
+  });
+
+  return <ApolloProvider client={client}>{element}</ApolloProvider>
+}

--- a/src/pages/__stories__/plan-a-route.stories.js
+++ b/src/pages/__stories__/plan-a-route.stories.js
@@ -1,12 +1,104 @@
-import PlanARoutePage from "../plan-a-route";
+import PlanARoutePage, {LIST_ROUTE_OPTIONS_QUERY} from "../plan-a-route";
 
 export default {
   title: "Pages/PlanARoute",
   component: PlanARoutePage,
-  tags: ["autodocs"],
 };
 
 export const Default = {
   args: {
   },
 };
+
+Default.parameters = {
+  layout: "fullscreen",
+  apolloClient: {
+    mocks: [
+      {
+        request: {
+          query: LIST_ROUTE_OPTIONS_QUERY,
+        },
+        variableMatcher: (variables) => true,
+        maxUsageCount: Number.POSITIVE_INFINITY,
+        result: {
+          data: {
+            "listRouteOptions": [
+              {
+                "__typename": "DockedEBikeRouteOption",
+                "provider": {
+                  "__typename": "Provider",
+                  "id": "tfl-santander-cycles",
+                  "name": "Santander Cycles"
+                },
+                "fromDockingStations": [
+                  {
+                    "__typename": "DockingStation",
+                    "id": "300249",
+                    "name": "Westminster Pier, Westminster",
+                    "location": {
+                      "__typename": "Coordinates",
+                      "longitude": -0.12382322,
+                      "latitude": 51.501513
+                    }
+                  },
+                  {
+                    "__typename": "DockingStation",
+                    "id": "200231",
+                    "name": "Abingdon Green, Westminster",
+                    "location": {
+                      "__typename": "Coordinates",
+                      "longitude": -0.12597218,
+                      "latitude": 51.49764
+                    }
+                  },
+                  {
+                    "__typename": "DockingStation",
+                    "id": "200202",
+                    "name": "Storey's Gate, Westminster",
+                    "location": {
+                      "__typename": "Coordinates",
+                      "longitude": -0.129698963,
+                      "latitude": 51.50070305
+                    }
+                  }
+                ],
+                "toDockingStations": [
+                  {
+                    "__typename": "DockingStation",
+                    "id": "001071",
+                    "name": "Tower Gardens , Tower",
+                    "location": {
+                      "__typename": "Coordinates",
+                      "longitude": -0.075459482,
+                      "latitude": 51.50950627
+                    }
+                  },
+                  {
+                    "__typename": "DockingStation",
+                    "id": "000991",
+                    "name": "Crosswall, Tower",
+                    "location": {
+                      "__typename": "Coordinates",
+                      "longitude": -0.077121322,
+                      "latitude": 51.51159481
+                    }
+                  },
+                  {
+                    "__typename": "DockingStation",
+                    "id": "200049",
+                    "name": "St. Katharine's Way, Tower",
+                    "location": {
+                      "__typename": "Coordinates",
+                      "longitude": -0.070542,
+                      "latitude": 51.505697
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+        },
+      },
+    ]
+  }
+}

--- a/src/pages/plan-a-route.js
+++ b/src/pages/plan-a-route.js
@@ -4,7 +4,6 @@ import RouteInputForm from "../components/RouteInputForm/RouteInputForm";
 import RouteOptionList from "../components/RouteOptionList/RouteOptionList";
 import { fn } from "@storybook/test";
 import { gql, useQuery } from "@apollo/client";
-import {Default as RouteMapStory} from "./__stories__/plan-a-route.stories";
 
 export const LIST_ROUTE_OPTIONS_QUERY = gql`
   query ListRouteOptions(
@@ -86,7 +85,7 @@ export default function PlanARoutePage() {
         />
         <SidebarContent />
       </aside>
-      <RouteMap style={{ height: "100%" }} route={RouteMapStory.args.route}/>
+      <RouteMap style={{ height: "100%" }}/>
     </main>
   );
 }

--- a/src/pages/plan-a-route.js
+++ b/src/pages/plan-a-route.js
@@ -1,19 +1,128 @@
-import React from "react"
+import React, { useState } from "react";
 import RouteMap from "../components/RouteMap/RouteMap";
 import RouteInputForm from "../components/RouteInputForm/RouteInputForm";
 import RouteOptionList from "../components/RouteOptionList/RouteOptionList";
-import {fn} from "@storybook/test";
-import {Default as RouteOptionListStory} from "../components/RouteOptionList/RouteOptionList.stories";
-import {DockedEbike as RouteMapStory} from "../components/RouteMap/RouteMap.stories";
+import { fn } from "@storybook/test";
+import { gql, useQuery } from "@apollo/client";
+import {Default as RouteMapStory} from "./__stories__/plan-a-route.stories";
+
+export const LIST_ROUTE_OPTIONS_QUERY = gql`
+  query ListRouteOptions(
+    $startingPointLongitude: Float!
+    $startingPointLatitude: Float!
+    $destinationLongitude: Float!
+    $destinationLatitude: Float!
+  ) {
+    listRouteOptions(
+      startingPointLongitude: $startingPointLongitude
+      startingPointLatitude: $startingPointLatitude
+      destinationLongitude: $destinationLongitude
+      destinationLatitude: $destinationLatitude
+    ) {
+      ... on DockedEBikeRouteOption {
+        provider {
+          id
+          name
+        }
+        fromDockingStations {
+          id
+          name
+          location {
+            longitude
+            latitude
+          }
+        }
+        toDockingStations {
+          id
+          name
+          location {
+            longitude
+            latitude
+          }
+        }
+      }
+    }
+  }
+`;
 
 export default function PlanARoutePage() {
+  const [startingPoint, setStartingPoint] = useState(null);
+  const [destination, setDestination] = useState(null);
+
+  const { loading, error, data } = useQuery(LIST_ROUTE_OPTIONS_QUERY, {
+    variables: {
+      startingPointLongitude: startingPoint && startingPoint.longitude,
+      startingPointLatitude: startingPoint && startingPoint.latitude,
+      destinationLongitude: destination && destination.longitude,
+      destinationLatitude: destination && destination.latitude,
+    },
+    skip: !startingPoint || !destination,
+  });
+
+  function SidebarContent() {
+    if (loading) {
+      return <span>Loading...</span>;
+    }
+    if (error) {
+      return <span>An error occurred</span>;
+    }
+    if (data) {
+      return (
+        <RouteOptionList
+          routeOptionProps={createRouteOptionProps(data)}
+          onRouteOptionSelected={fn()}
+        />
+      );
+    }
+    return <></>;
+  }
+
   return (
-    <main style={{ height: "100vh"}}>
-      <aside style={{width: "350px", float: "left"}}>
-        <RouteInputForm onStartingPointChange={fn()} onDestinationChange={fn()}/>
-        <RouteOptionList routeOptionProps={RouteOptionListStory.args.routeOptionProps} />
+    <main style={{ height: "100vh" }}>
+      <aside style={{ width: "350px", float: "left" }}>
+        <RouteInputForm
+          onStartingPointChange={location => setStartingPoint(location.coordinates)}
+          onDestinationChange={location => setDestination(location.coordinates)}
+        />
+        <SidebarContent />
       </aside>
       <RouteMap style={{ height: "100%" }} route={RouteMapStory.args.route}/>
     </main>
-  )
-};
+  );
+}
+
+function createRouteOptionProps(data) {
+  if (data) {
+    return data["listRouteOptions"]
+      .map((routeOption) => {
+        switch (routeOption["__typename"]) {
+          case "DockedEBikeRouteOption":
+            return createDockedEbikeRouteOptionProps(routeOption);
+          default:
+            console.log(`Unknown type: '${routeOption["__typename"]}'.`);
+            return null;
+        }
+      })
+      .filter((option) => option);
+  } else {
+    return [];
+  }
+}
+
+function createDockedEbikeRouteOptionProps(data) {
+  const mapDockingStation = (station) => ({
+    value: station["id"],
+    label: station["name"],
+  });
+
+  return {
+    type: "docked-ebike",
+    provider: {
+      id: data["provider"]["id"],
+      name: data["provider"]["name"],
+    },
+    fromDockingStations: data["fromDockingStations"].map(mapDockingStation),
+    toDockingStations: data["toDockingStations"].map(mapDockingStation),
+    onDockingStationChange: fn(),
+  };
+}


### PR DESCRIPTION
# Changelist
- Add apollo graphql client dependency
- Add apollo grpahql client storybook addon
- Inject apollo graphql client provider into dom root (url: https://micro-commute-backend.onrender.com/graphql)
- Add starting point and destination states to /plan-a-route page
- Query route options via graphql and populate route options list with it
- Add mocked graphql responses for /plan-a-route page story in storybook
- Set /plan-a-route page story in storybook to fullscreen mode for correct rendering
- Pre-select first route option in route option list

# Screenshots
![image](https://github.com/user-attachments/assets/c5f6bbf1-4623-45ae-9b78-ed6a3c5ca759)
