### PR TITLE
MC-27: Refactor route options list into a controlled component

### DIFF
--- a/src/components/RouteOption/DockedEbikeRouteOption.jsx
+++ b/src/components/RouteOption/DockedEbikeRouteOption.jsx
@@ -1,32 +1,36 @@
-import React, {useState} from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import Style from "react-style-proptype";
+import { RouteOptionPropType } from "../../lib/types";
 
-export default function DockedEbikeRouteOption(props) {
-  const nStationsFrom = props.fromDockingStations.length;
-  const nStationsTo = props.toDockingStations.length;
-
-  const style = {
-    backgroundColor: props.isSelected ? "cyan" : "inherit",
-  };
+export default function DockedEbikeRouteOption({
+  routeOption,
+  isSelected,
+  onClick,
+}) {
+  const { fromDockingStations } = routeOption.extraProperties;
+  const { toDockingStations } = routeOption.extraProperties;
 
   return (
-    <article onClick={props.onClick} style={style}>
+    <article
+      onClick={onClick}
+      style={{ backgroundColor: isSelected ? "cyan" : "inherit" }}
+    >
       <header>
-        <h1>{props.provider.name}</h1>
+        <h1>{routeOption.provider.name}</h1>
       </header>
-      {nStationsFrom > 0 && nStationsTo > 0 ? (
+      {fromDockingStations.length > 0 && toDockingStations.length > 0 ? (
         <div style={{ display: "flex" }}>
           <DockingStationSelector
             label="From docking station"
-            stations={props.fromDockingStations}
-            onSelect={props.onFromDockingStationSelect}
+            stations={fromDockingStations}
+            onSelect={() => null}
             style={{ flex: 1 }}
           />
           <DockingStationSelector
             label="To docking station"
-            stations={props.toDockingStations}
-            onSelect={props.onToDockingStationSelect}
+            stations={toDockingStations}
+            onSelect={() => null}
             style={{ flex: 1 }}
           />
         </div>
@@ -38,24 +42,7 @@ export default function DockedEbikeRouteOption(props) {
 }
 
 DockedEbikeRouteOption.propTypes = {
-  provider: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    name: PropTypes.string.isRequired,
-  }),
-  fromDockingStations: PropTypes.arrayOf(
-    PropTypes.shape({
-      value: PropTypes.string.isRequired,
-      label: PropTypes.string.isRequired,
-    }),
-  ),
-  toDockingStations: PropTypes.arrayOf(
-    PropTypes.shape({
-      value: PropTypes.string.isRequired,
-      label: PropTypes.string.isRequired,
-    }),
-  ),
-  onFromDockingStationSelect: PropTypes.func.isRequired,
-  onToDockingStationSelect: PropTypes.func.isRequired,
+  routeOption: RouteOptionPropType.isRequired,
   isSelected: PropTypes.bool.isRequired,
   onClick: PropTypes.func.isRequired,
 };
@@ -63,8 +50,6 @@ DockedEbikeRouteOption.propTypes = {
 DockedEbikeRouteOption.defaultProps = {
   isSelected: false,
 };
-
-DockedEbikeRouteOption.TYPE = "docked-ebike";
 
 /** Pre-condition: options.length > 0 */
 function DockingStationSelector({ label, stations, onSelect, style }) {
@@ -74,7 +59,7 @@ function DockingStationSelector({ label, stations, onSelect, style }) {
     let stationId = e.target.value;
     setSelectedStation(stationId);
     onSelect(stationId);
-  }
+  };
 
   return (
     <div style={style}>

--- a/src/components/RouteOption/RouteOption.jsx
+++ b/src/components/RouteOption/RouteOption.jsx
@@ -1,15 +1,26 @@
 import React from "react";
-import PropTypes from "prop-types";
 import DockedEbikeRouteOption from "./DockedEbikeRouteOption";
+import { RouteOptionPropType, TransportType } from "../../lib/types";
+import PropTypes from "prop-types";
 
-export default function RouteOption({ type, ...props }) {
-  if (type === DockedEbikeRouteOption.TYPE) {
-    return <DockedEbikeRouteOption {...props} />;
+export default function RouteOption({ routeOption, isSelected, select }) {
+  if (routeOption.transportType === TransportType.DOCKED_EBIKE) {
+    return (
+      <DockedEbikeRouteOption
+        routeOption={routeOption}
+        isSelected={isSelected}
+        onClick={() => select(routeOption)}
+      />
+    );
   } else {
-    throw new TypeError(`Unknown route option type: '${type}'.`);
+    throw new TypeError(
+      `Unknown transport type: '${routeOption.transportType}'.`,
+    );
   }
 }
 
 RouteOption.propTypes = {
-  type: PropTypes.oneOf([DockedEbikeRouteOption.TYPE]),
+  routeOption: RouteOptionPropType,
+  isSelected: PropTypes.bool.isRequired,
+  select: PropTypes.func.isRequired, // args: (routeOption)
 };

--- a/src/components/RouteOption/RouteOption.stories.js
+++ b/src/components/RouteOption/RouteOption.stories.js
@@ -1,5 +1,6 @@
 import RouteOption from "./RouteOption";
 import { fn } from "@storybook/test";
+import { TransportType } from "../../lib/types";
 
 export default {
   title: "Components/RouteOption",
@@ -9,56 +10,62 @@ export default {
 
 export const DockedEbike = {
   args: {
-    type: "docked-ebike",
-    provider: {
-      id: "some-provider",
-      name: "Some provider",
+    routeOption: {
+      provider: {
+        id: "some-provider",
+        name: "Some provider",
+      },
+      transportType: TransportType.DOCKED_EBIKE,
+      extraProperties: {
+        fromDockingStations: [
+          { id: "foo", name: "Foo street, 123" },
+          { id: "bar", name: "Bar street, 123" },
+          { id: "baz", name: "Baz street, 123" },
+        ],
+        toDockingStations: [{ id: "qux", name: "Qux street, 123" }],
+      },
     },
-    fromDockingStations: [
-      { id: "foo", name: "Foo street, 123" },
-      { id: "bar", name: "Bar street, 123" },
-      { id: "baz", name: "Baz street, 123" },
-    ],
-    toDockingStations: [{ id: "qux", name: "Qux street, 123" }],
-    onFromDockingStationSelect: fn(),
-    onToDockingStationSelect: fn(),
     isSelected: false,
-    onClick: fn(),
+    select: fn(),
   },
 };
 
 export const DockedEbikeEmpty = {
   args: {
-    type: "docked-ebike",
-    provider: {
-      id: "some-provider",
-      name: "Some provider",
+    routeOption: {
+      provider: {
+        id: "some-provider",
+        name: "Some provider",
+      },
+      transportType: TransportType.DOCKED_EBIKE,
+      extraProperties: {
+        fromDockingStations: [],
+        toDockingStations: [],
+      },
     },
-    fromDockingStations: [],
-    toDockingStations: [],
-    onFromDockingStationSelect: fn(),
-    onToDockingStationSelect: fn(),
     isSelected: false,
-    onClick: fn(),
+    select: fn(),
   },
 };
 
 export const DockedEbikeSelected = {
   args: {
-    type: "docked-ebike",
-    provider: {
-      id: "some-provider",
-      name: "Some provider",
+    routeOption: {
+      provider: {
+        id: "some-provider",
+        name: "Some provider",
+      },
+      transportType: TransportType.DOCKED_EBIKE,
+      extraProperties: {
+        fromDockingStations: [
+          { id: "foo", name: "Foo street, 123" },
+          { id: "bar", name: "Bar street, 123" },
+          { id: "baz", name: "Baz street, 123" },
+        ],
+        toDockingStations: [{ id: "qux", name: "Qux street, 123" }],
+      },
     },
-    fromDockingStations: [
-      { id: "foo", name: "Foo street, 123" },
-      { id: "bar", name: "Bar street, 123" },
-      { id: "baz", name: "Baz street, 123" },
-    ],
-    toDockingStations: [{ id: "qux", name: "Qux street, 123" }],
-    onFromDockingStationSelect: fn(),
-    onToDockingStationSelect: fn(),
     isSelected: true,
-    onClick: fn(),
+    select: fn(),
   },
 };

--- a/src/components/RouteOptionList/RouteOptionList.jsx
+++ b/src/components/RouteOptionList/RouteOptionList.jsx
@@ -1,22 +1,39 @@
-import React, {useState} from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import RouteOption from "../RouteOption/RouteOption";
+import { RouteOptionPropType, RoutePropType } from "../../lib/types";
 
-export default function RouteOptionList({routeOptionProps, onRouteOptionSelected}) {
-  const [selectedIndex, setSelectedIndex] = useState(0);
+export default function RouteOptionList({
+  routeOptions,
+  activeRoute,
+  setActiveRoute,
+}) {
+  function isSelected(routeOption) {
+    return (
+      routeOption.provider.id === activeRoute.providerId &&
+      routeOption.transportType === activeRoute.transportType
+    );
+  }
 
-  const handleOptionClick = (index, provider, routeType) => {
-    setSelectedIndex(index);
-    onRouteOptionSelected(provider.id, routeType);
-  };
+  function selectRoute(routeOption) {
+    setActiveRoute((activeRoute) => ({
+      ...activeRoute,
+      providerId: routeOption.provider.id,
+      transportType: routeOption.transportType,
+    }));
+  }
 
   return (
     <div>
-      {routeOptionProps.map((props, index) => (
+      {routeOptions.map((routeOption) => (
         <RouteOption
-          {...props}
-          isSelected={index === selectedIndex}
-          onClick={() => handleOptionClick(index, props.provider, props.type)}
+          routeOption={routeOption}
+          isSelected={isSelected(routeOption)}
+          select={() => {
+            if (!isSelected(routeOption)) {
+              selectRoute(routeOption);
+            }
+          }}
         />
       ))}
     </div>
@@ -24,6 +41,7 @@ export default function RouteOptionList({routeOptionProps, onRouteOptionSelected
 }
 
 RouteOptionList.propTypes = {
-  routeOptionProps: PropTypes.arrayOf(PropTypes.shape(RouteOption.propTypes)),
-  onRouteOptionSelected: PropTypes.func.isRequired,
-}
+  routeOptions: PropTypes.arrayOf(RouteOptionPropType),
+  activeRoute: RoutePropType,
+  setActiveRoute: PropTypes.func.isRequired,
+};

--- a/src/components/RouteOptionList/RouteOptionList.stories.js
+++ b/src/components/RouteOptionList/RouteOptionList.stories.js
@@ -1,5 +1,7 @@
+import React from "react";
 import RouteOptionList from "./RouteOptionList";
-import {fn} from "@storybook/test";
+import { TransportType } from "../../lib/types";
+import { useState } from "react";
 
 export default {
   title: "Components/RouteOptionList",
@@ -8,37 +10,53 @@ export default {
 };
 
 export const Default = {
+  render: function ({ routeOptions }) {
+    const [activeRoute, setActiveRoute] = useState({
+      providerId: "some-provider",
+      transportType: TransportType.DOCKED_EBIKE,
+    });
+    return (
+      <RouteOptionList
+        routeOptions={routeOptions}
+        activeRoute={activeRoute}
+        setActiveRoute={setActiveRoute}
+      />
+    );
+  },
   args: {
-    routeOptionProps: [
+    routeOptions: [
       {
-        type: "docked-ebike",
         provider: {
           id: "some-provider",
           name: "Some provider",
         },
-        fromDockingStations: [
-          { value: "foo", label: "Foo street, 123" },
-          { value: "bar", label: "Bar street, 123" },
-          { value: "baz", label: "Baz street, 123" },
-        ],
-        toDockingStations: [{ value: "qux", label: "Qux street, 123" }],
-        onDockingStationChange: fn(),
+        transportType: TransportType.DOCKED_EBIKE,
+        extraProperties: {
+          fromDockingStations: [
+            { id: "foo", name: "Foo street, 123" },
+            { id: "bar", name: "Bar street, 123" },
+            { id: "baz", name: "Baz street, 123" },
+          ],
+          toDockingStations: [{ id: "qux", name: "Qux street, 123" }],
+        },
       },
       {
-        type: "docked-ebike",
         provider: {
           id: "other-provider",
-          name: "Some provider",
+          name: "Other provider",
         },
-        fromDockingStations: [
-          { value: "lorem", label: "Lorem street, 123" },
-          { value: "ipsum", label: "Ipsum street, 123" },
-          { value: "dolor", label: "Dolor street, 123" },
-        ],
-        toDockingStations: [{ value: "et", label: "Et street, 123" }],
-        onDockingStationChange: fn(),
-      }
+        transportType: TransportType.DOCKED_EBIKE,
+        extraProperties: {
+          fromDockingStations: [
+            { id: "lorem", name: "Lorem street, 123" },
+            { id: "ipsum", name: "Ipsum street, 123" },
+          ],
+          toDockingStations: [
+            { id: "dolor", name: "Dolor street, 123" },
+            { id: "et", name: "Et street, 123" },
+          ],
+        },
+      },
     ],
-    onRouteOptionSelected: fn(),
   },
 };

--- a/src/lib/route.js
+++ b/src/lib/route.js
@@ -1,10 +1,7 @@
 import PropTypes from "prop-types";
+import { CoordinatesPropType } from "./types";
 
-export const CoordinatesPropType = PropTypes.shape({
-  longitude: PropTypes.number.isRequired,
-  latitude: PropTypes.number.isRequired,
-});
-
+/** @deprecated - use RoutePropType from types.js */
 export const DockedEbikeRoutePropType = PropTypes.shape({
   type: PropTypes.oneOf(["docked-ebike"]),
   startingPoint: CoordinatesPropType.isRequired,
@@ -13,6 +10,5 @@ export const DockedEbikeRoutePropType = PropTypes.shape({
   destinationDockingStation: CoordinatesPropType.isRequired,
 });
 
-export const RoutePropType = PropTypes.oneOfType([
-  DockedEbikeRoutePropType,
-]);
+/** @deprecated - use RoutePropType from types.js */
+export const RoutePropType = PropTypes.oneOfType([DockedEbikeRoutePropType]);

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -1,0 +1,31 @@
+import PropTypes from "prop-types";
+
+export const TransportType = Object.freeze({
+  DOCKED_EBIKE: "docked-ebike",
+});
+
+export const TransportTypePropType = PropTypes.oneOf(
+  Object.values(TransportType),
+);
+
+export const RouteOptionPropType = PropTypes.shape({
+  provider: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+  }),
+  transportType: TransportTypePropType,
+  extraProperties: PropTypes.object.isRequired,
+});
+
+export const CoordinatesPropType = PropTypes.shape({
+  latitude: PropTypes.number.isRequired,
+  longitude: PropTypes.number.isRequired,
+});
+
+export const RoutePropType = PropTypes.shape({
+  providerId: PropTypes.string.isRequired,
+  transportType: PropTypes.string.isRequired,
+  startingPoint: CoordinatesPropType.isRequired,
+  destination: CoordinatesPropType.isRequired,
+  extraProperties: PropTypes.object.isRequired,
+});

--- a/src/pages/__stories__/plan-a-trip.stories.js
+++ b/src/pages/__stories__/plan-a-trip.stories.js
@@ -1,4 +1,4 @@
-import PlanATripPage, {LIST_ROUTE_OPTIONS_QUERY} from "../plan-a-trip";
+import PlanATripPage, { LIST_ROUTE_OPTIONS_QUERY } from "../plan-a-trip";
 
 export default {
   title: "Pages/PlanATrip",
@@ -6,8 +6,7 @@ export default {
 };
 
 export const Default = {
-  args: {
-  },
+  args: {},
 };
 
 Default.parameters = {
@@ -20,85 +19,86 @@ Default.parameters = {
         },
         variableMatcher: (variables) => true,
         maxUsageCount: Number.POSITIVE_INFINITY,
+        delay: 500,
         result: {
           data: {
-            "listRouteOptions": [
+            listRouteOptions: [
               {
-                "__typename": "DockedEBikeRouteOption",
-                "provider": {
-                  "__typename": "Provider",
-                  "id": "tfl-santander-cycles",
-                  "name": "Santander Cycles"
+                __typename: "DockedEBikeRouteOption",
+                provider: {
+                  __typename: "Provider",
+                  id: "tfl-santander-cycles",
+                  name: "Santander Cycles",
                 },
-                "fromDockingStations": [
+                fromDockingStations: [
                   {
-                    "__typename": "DockingStation",
-                    "id": "300249",
-                    "name": "Westminster Pier, Westminster",
-                    "location": {
-                      "__typename": "Coordinates",
-                      "longitude": -0.12382322,
-                      "latitude": 51.501513
-                    }
+                    __typename: "DockingStation",
+                    id: "300249",
+                    name: "Westminster Pier, Westminster",
+                    location: {
+                      __typename: "Coordinates",
+                      longitude: -0.12382322,
+                      latitude: 51.501513,
+                    },
                   },
                   {
-                    "__typename": "DockingStation",
-                    "id": "200231",
-                    "name": "Abingdon Green, Westminster",
-                    "location": {
-                      "__typename": "Coordinates",
-                      "longitude": -0.12597218,
-                      "latitude": 51.49764
-                    }
+                    __typename: "DockingStation",
+                    id: "200231",
+                    name: "Abingdon Green, Westminster",
+                    location: {
+                      __typename: "Coordinates",
+                      longitude: -0.12597218,
+                      latitude: 51.49764,
+                    },
                   },
                   {
-                    "__typename": "DockingStation",
-                    "id": "200202",
-                    "name": "Storey's Gate, Westminster",
-                    "location": {
-                      "__typename": "Coordinates",
-                      "longitude": -0.129698963,
-                      "latitude": 51.50070305
-                    }
-                  }
+                    __typename: "DockingStation",
+                    id: "200202",
+                    name: "Storey's Gate, Westminster",
+                    location: {
+                      __typename: "Coordinates",
+                      longitude: -0.129698963,
+                      latitude: 51.50070305,
+                    },
+                  },
                 ],
-                "toDockingStations": [
+                toDockingStations: [
                   {
-                    "__typename": "DockingStation",
-                    "id": "001071",
-                    "name": "Tower Gardens , Tower",
-                    "location": {
-                      "__typename": "Coordinates",
-                      "longitude": -0.075459482,
-                      "latitude": 51.50950627
-                    }
+                    __typename: "DockingStation",
+                    id: "001071",
+                    name: "Tower Gardens , Tower",
+                    location: {
+                      __typename: "Coordinates",
+                      longitude: -0.075459482,
+                      latitude: 51.50950627,
+                    },
                   },
                   {
-                    "__typename": "DockingStation",
-                    "id": "000991",
-                    "name": "Crosswall, Tower",
-                    "location": {
-                      "__typename": "Coordinates",
-                      "longitude": -0.077121322,
-                      "latitude": 51.51159481
-                    }
+                    __typename: "DockingStation",
+                    id: "000991",
+                    name: "Crosswall, Tower",
+                    location: {
+                      __typename: "Coordinates",
+                      longitude: -0.077121322,
+                      latitude: 51.51159481,
+                    },
                   },
                   {
-                    "__typename": "DockingStation",
-                    "id": "200049",
-                    "name": "St. Katharine's Way, Tower",
-                    "location": {
-                      "__typename": "Coordinates",
-                      "longitude": -0.070542,
-                      "latitude": 51.505697
-                    }
-                  }
-                ]
-              }
-            ]
+                    __typename: "DockingStation",
+                    id: "200049",
+                    name: "St. Katharine's Way, Tower",
+                    location: {
+                      __typename: "Coordinates",
+                      longitude: -0.070542,
+                      latitude: 51.505697,
+                    },
+                  },
+                ],
+              },
+            ],
           },
         },
       },
-    ]
-  }
-}
+    ],
+  },
+};


### PR DESCRIPTION
Remodel route options around 'route options' and 'active route' state. This is the first step into setting up a single shared state for the current 'active route', which will live in the top-level plan-a-trip page and which we will propagate to descendants as necessary.