### PR TITLE
MC-53: Implement 'plan a trip' use case from landing page

### DIFF
--- a/src/components/RouteInputForm/RouteInputForm.jsx
+++ b/src/components/RouteInputForm/RouteInputForm.jsx
@@ -10,9 +10,17 @@ const RouteInputForm = ({
   onDestinationChange,
   arriveByDateTimeValue,
   onArriveByDateTimeChange,
+  orientation,
 }) => {
   return (
-    <form>
+    <form
+      style={{
+        display: "flex",
+        alignItems: "stretch",
+        flexDirection: orientation,
+        gap: "0.5rem",
+      }}
+    >
       <div>
         <label id="starting-point-label">Starting point</label>
         <LocationInput
@@ -59,6 +67,7 @@ RouteInputForm.propTypes = {
   onDestinationChange: PropTypes.func.isRequired,
   arriveByDateTimeValue: PropTypes.string.isRequired,
   onArriveByDateTimeChange: PropTypes.func.isRequired,
+  orientation: PropTypes.oneOf(["column", "row"]).isRequired,
 };
 
 export default RouteInputForm;

--- a/src/components/RouteInputForm/RouteInputForm.stories.jsx
+++ b/src/components/RouteInputForm/RouteInputForm.stories.jsx
@@ -8,7 +8,7 @@ export default {
   tags: ["autodocs"],
 };
 
-export const Default = {
+export const Row = {
   args: {
     startingPointValue: null,
     onStartingPointChange: fn(),
@@ -16,44 +16,61 @@ export const Default = {
     onDestinationChange: fn(),
     arriveByDateTimeValue: "2023-09-10T10:00",
     onArriveByDateTimeChange: fn(),
+    orientation: "row",
   },
-  render: function (args) {
-    const [startingPointValue, setStartingPointValue] = useState(
-      args.startingPointValue,
-    );
-
-    const [destinationValue, setDestinationValue] = useState(
-      args.destinationValue,
-    );
-
-    const [arriveByDateTime, setArriveByDateTime] = useState(
-      args.arriveByDateTimeValue,
-    );
-
-    function onStartingPointChange(location) {
-      args.onStartingPointChange(location); // fn() for debugging
-      setStartingPointValue(location);
-    }
-
-    function onDestinationChange(location) {
-      args.onDestinationChange(location); // fn() for debugging
-      setDestinationValue(location);
-    }
-
-    function onArriveByDateTimeChange(datetime) {
-      args.onArriveByDateTimeChange(datetime); // fn() for debugging
-      setArriveByDateTime(datetime);
-    }
-
-    return (
-      <RouteInputForm
-        startingPointValue={startingPointValue}
-        onStartingPointChange={onStartingPointChange}
-        destinationValue={destinationValue}
-        onDestinationChange={onDestinationChange}
-        arriveByDateTimeValue={arriveByDateTime}
-        onArriveByDateTimeChange={onArriveByDateTimeChange}
-      />
-    );
-  },
+  render: renderRouteInputForm,
 };
+
+export const Column = {
+  args: {
+    startingPointValue: null,
+    onStartingPointChange: fn(),
+    destinationValue: null,
+    onDestinationChange: fn(),
+    arriveByDateTimeValue: "2023-09-10T10:00",
+    onArriveByDateTimeChange: fn(),
+    orientation: "column",
+  },
+  render: renderRouteInputForm,
+};
+
+function renderRouteInputForm(args) {
+  const [startingPointValue, setStartingPointValue] = useState(
+    args.startingPointValue,
+  );
+
+  const [destinationValue, setDestinationValue] = useState(
+    args.destinationValue,
+  );
+
+  const [arriveByDateTime, setArriveByDateTime] = useState(
+    args.arriveByDateTimeValue,
+  );
+
+  function onStartingPointChange(location) {
+    args.onStartingPointChange(location); // fn() for debugging
+    setStartingPointValue(location);
+  }
+
+  function onDestinationChange(location) {
+    args.onDestinationChange(location); // fn() for debugging
+    setDestinationValue(location);
+  }
+
+  function onArriveByDateTimeChange(datetime) {
+    args.onArriveByDateTimeChange(datetime); // fn() for debugging
+    setArriveByDateTime(datetime);
+  }
+
+  return (
+    <RouteInputForm
+      startingPointValue={startingPointValue}
+      onStartingPointChange={onStartingPointChange}
+      destinationValue={destinationValue}
+      onDestinationChange={onDestinationChange}
+      arriveByDateTimeValue={arriveByDateTime}
+      onArriveByDateTimeChange={onArriveByDateTimeChange}
+      orientation={args.orientation}
+    />
+  );
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,41 +1,98 @@
 import * as React from "react";
-import RouteMap from "../components/RouteMap/RouteMap";
-
-const pageStyles = {
-  color: "#232129",
-  padding: 96,
-  fontFamily: "-apple-system, Roboto, sans-serif, serif",
-};
-const headingStyles = {
-  marginTop: 0,
-  marginBottom: 64,
-  maxWidth: 320,
-};
-const headingAccentStyles = {
-  color: "#663399",
-};
-const paragraphStyles = {
-  marginBottom: 48,
-};
+import { useEffect } from "react";
+import {
+  arriveByDateTimeChanged,
+  destinationChanged,
+  fetchRouteOptions,
+  selectArriveBy,
+  selectDestination,
+  selectStartingPoint,
+  startingPointChanged,
+} from "../modules/planatrip/planATripSlice";
+import RouteInputForm from "../components/RouteInputForm/RouteInputForm";
+import { useDispatch, useSelector } from "react-redux";
+import { useApolloClient } from "@apollo/client";
+import { navigate } from "gatsby";
 
 const IndexPage = () => {
+  const dispatch = useDispatch();
+  const startingPoint = useSelector(selectStartingPoint);
+  const destination = useSelector(selectDestination);
+  const arriveBy = useSelector(selectArriveBy);
+  const graphQLClient = useApolloClient();
+
+  useEffect(() => {
+    if (startingPoint && destination) {
+      dispatch(
+        fetchRouteOptions({
+          client: graphQLClient,
+          variables: {
+            startingPoint: startingPoint,
+            destination: destination,
+          },
+        }),
+      );
+    }
+  }, [dispatch, startingPoint, destination, graphQLClient]);
+
   return (
-    <main style={pageStyles}>
-      <h1 style={headingStyles}>
-        Micro-Commute
-        <br />
-        <span style={headingAccentStyles}>
-          — shared mobility for your commute 🌱🚴🏡
+    <main
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        height: "100vh",
+        justifyContent: "center",
+        gap: "0.5rem",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          alignItems: "baseline",
+        }}
+      >
+        <h1 style={{ fontSize: "2rem" }}>Micro-Commute</h1>
+        <span style={{ fontSize: "1.2rem", marginLeft: "1rem" }}>
+          Solving the first and last mile problem.
         </span>
-      </h1>
-      <p style={paragraphStyles}>
-        Solving the first and last mile problem for urban commuters.
-      </p>
-      <RouteMap />
+      </div>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          alignItems: "flex-end",
+        }}
+      >
+        <RouteInputForm
+          startingPointValue={startingPoint}
+          onStartingPointChange={(location) => {
+            // noinspection JSCheckFunctionSignatures
+            dispatch(startingPointChanged(location));
+          }}
+          destinationValue={destination}
+          onDestinationChange={(location) => {
+            // noinspection JSCheckFunctionSignatures
+            dispatch(destinationChanged(location));
+          }}
+          arriveByDateTimeValue={arriveBy}
+          onArriveByDateTimeChange={(dateTime) => {
+            // noinspection JSCheckFunctionSignatures
+            dispatch(arriveByDateTimeChanged(dateTime));
+          }}
+          orientation="row"
+        />
+        <button
+          style={{ marginLeft: "0.5rem" }}
+          onClick={() => navigate("/plan-a-trip")}
+        >
+          Let's Go!
+        </button>
+      </div>
+      <p>Your local bike share options — simplified, personalized. 🌱🚴🏡</p>
     </main>
   );
 };
 
 export default IndexPage;
-
-export const Head = () => <title>Micro-Commute</title>;

--- a/src/pages/plan-a-trip.js
+++ b/src/pages/plan-a-trip.js
@@ -58,6 +58,7 @@ export default function PlanATripPage() {
             // noinspection JSCheckFunctionSignatures
             dispatch(arriveByDateTimeChanged(dateTime));
           }}
+          orientation="column"
         />
         {(() => {
           switch (loadingStatus) {


### PR DESCRIPTION
# Changelist
- Add an `orientation` property to the `RouteInputForm` so that we can display it in "landscape" or "portrait" mode
- Clear leftovers from gatsby init from index page and add `RouteInputForm` with button to /plan-a-trip page
- Add a catchy tagline

# Demo
https://github.com/user-attachments/assets/3e51e152-ad7b-427e-8af7-0acb2720d3d5

# Author
The original author for these changes is @Lmason618 - credit to him