### PR TITLE
MC-53: Remove fetch route options effect from index

### DIFF
--- a/src/components/DateTimeInput/DateTimeInput.jsx
+++ b/src/components/DateTimeInput/DateTimeInput.jsx
@@ -6,7 +6,7 @@ const DateTimeInput = ({ value, onChange }) => {
     <div>
       <input
         type="datetime-local"
-        value={value}
+        value={value || ""}
         onChange={(e) => onChange(e.target.value)}
       />
     </div>

--- a/src/components/RouteInputForm/RouteInputForm.jsx
+++ b/src/components/RouteInputForm/RouteInputForm.jsx
@@ -65,7 +65,7 @@ RouteInputForm.propTypes = {
     }),
   }),
   onDestinationChange: PropTypes.func.isRequired,
-  arriveByDateTimeValue: PropTypes.string.isRequired,
+  arriveByDateTimeValue: PropTypes.string,
   onArriveByDateTimeChange: PropTypes.func.isRequired,
   orientation: PropTypes.oneOf(["column", "row"]).isRequired,
 };

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,9 +1,7 @@
 import * as React from "react";
-import { useEffect } from "react";
 import {
   arriveByDateTimeChanged,
   destinationChanged,
-  fetchRouteOptions,
   selectArriveBy,
   selectDestination,
   selectStartingPoint,
@@ -11,7 +9,6 @@ import {
 } from "../modules/planatrip/planATripSlice";
 import RouteInputForm from "../components/RouteInputForm/RouteInputForm";
 import { useDispatch, useSelector } from "react-redux";
-import { useApolloClient } from "@apollo/client";
 import { navigate } from "gatsby";
 
 const IndexPage = () => {
@@ -19,21 +16,6 @@ const IndexPage = () => {
   const startingPoint = useSelector(selectStartingPoint);
   const destination = useSelector(selectDestination);
   const arriveBy = useSelector(selectArriveBy);
-  const graphQLClient = useApolloClient();
-
-  useEffect(() => {
-    if (startingPoint && destination) {
-      dispatch(
-        fetchRouteOptions({
-          client: graphQLClient,
-          variables: {
-            startingPoint: startingPoint,
-            destination: destination,
-          },
-        }),
-      );
-    }
-  }, [dispatch, startingPoint, destination, graphQLClient]);
 
   return (
     <main


### PR DESCRIPTION
Main change:
We already fetch the routes from the plan-a-trip page. Fetching them also from the index page is unnecessary.

Boyscouting:
- Default datetime input value to empty string (otherwise, the component is not controlled from the start, as it starts with value null - when that happens, react shows a warning 'component changing from uncontrolled to controlled')
