### PR TITLE
MC-63: Adjust docked e-bike route card layout

### DIFF
--- a/src/components/DateTimeInput/DateTimeInput.jsx
+++ b/src/components/DateTimeInput/DateTimeInput.jsx
@@ -1,13 +1,15 @@
 import React from "react";
 import PropTypes from "prop-types";
+import Style from "react-style-proptype";
 
-const DateTimeInput = ({ value, onChange }) => {
+const DateTimeInput = ({ value, onChange, style = undefined }) => {
   return (
     <div>
       <input
         type="datetime-local"
         value={value || ""}
         onChange={(e) => onChange(e.target.value)}
+        style={style}
       />
     </div>
   );
@@ -16,6 +18,7 @@ const DateTimeInput = ({ value, onChange }) => {
 DateTimeInput.propTypes = {
   value: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
+  style: Style,
 };
 
 export default DateTimeInput;

--- a/src/components/LocationInput/LocationInput.jsx
+++ b/src/components/LocationInput/LocationInput.jsx
@@ -11,6 +11,7 @@ export default function LocationInput({
   onLocationChange,
   searchDelayMillis = 500,
   ariaLabelledBy = null,
+  style = undefined,
 }) {
   const [searchTerm, setSearchTerm] = useState("");
   const [results, setResults] = useState([]);
@@ -54,6 +55,7 @@ export default function LocationInput({
       <input
         type="text"
         placeholder="Enter address"
+        style={style}
         value={(() => {
           switch (state) {
             case "idle":

--- a/src/components/RouteInputForm/RouteInputForm.jsx
+++ b/src/components/RouteInputForm/RouteInputForm.jsx
@@ -11,7 +11,9 @@ const RouteInputForm = ({
   arriveByDateTimeValue,
   onArriveByDateTimeChange,
   orientation,
+  styleOverrides = undefined,
 }) => {
+  const inputWidth = orientation === "column" ? "250px" : undefined;
   return (
     <form
       style={{
@@ -19,6 +21,7 @@ const RouteInputForm = ({
         alignItems: "stretch",
         flexDirection: orientation,
         gap: "0.5rem",
+        ...(styleOverrides || {}),
       }}
     >
       <div>
@@ -27,6 +30,7 @@ const RouteInputForm = ({
           locationValue={startingPointValue}
           onLocationChange={onStartingPointChange}
           ariaLabelledBy="starting-point-label"
+          style={{width: inputWidth}}
         />
       </div>
       <div>
@@ -35,6 +39,7 @@ const RouteInputForm = ({
           locationValue={destinationValue}
           onLocationChange={onDestinationChange}
           ariaLabelledBy="destination-label"
+          style={{width: inputWidth }}
         />
       </div>
       <div>
@@ -42,6 +47,7 @@ const RouteInputForm = ({
         <DateTimeInput
           value={arriveByDateTimeValue}
           onChange={onArriveByDateTimeChange}
+          style={{width: inputWidth }}
         />
       </div>
     </form>

--- a/src/components/RouteOption/DockedEbikeRouteOption.jsx
+++ b/src/components/RouteOption/DockedEbikeRouteOption.jsx
@@ -112,6 +112,7 @@ function DockingStationSelector({ label, value, stations, onChange, style }) {
         // Prevent DockedEbikeRouteOption 'onClick' when clicking on this select
         onClick={(e) => e.stopPropagation()}
         aria-labelledby={labelId}
+        style={{width: "100%"}}
       >
         {stations.map((station) => (
           <option value={station.id} key={station.id}>

--- a/src/components/RouteOption/DockedEbikeRouteOption.module.css
+++ b/src/components/RouteOption/DockedEbikeRouteOption.module.css
@@ -1,0 +1,17 @@
+h1 {
+  font-size: 1.2rem;
+  font-weight: bold;
+  margin-bottom: 0.1rem;
+}
+
+.dockedEbikeRouteOptionDetails strong {
+  font-weight: bold;
+}
+
+.dockedEbikeRouteOptionDetails .label {
+  font-size: 0.95rem;
+}
+
+.dockedEbikeRouteOptionDetails .smallLabel {
+  font-size: 0.85rem;
+}

--- a/src/components/RouteOption/DockedEbikeRouteOptionDetails.jsx
+++ b/src/components/RouteOption/DockedEbikeRouteOptionDetails.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { formatDurationToHumanReadableWithMinutePrecision } from "../../modules/util";
+import * as styles from "./DockedEbikeRouteOption.module.css";
 
 export default function DockedEbikeRouteOptionDetails({ routeOption }) {
   const {
@@ -15,109 +16,103 @@ export default function DockedEbikeRouteOptionDetails({ routeOption }) {
     usualAvailabilityAtBikePickupStation,
     usualAvailabilityAtBikeDropOffStation,
   } = routeOption.details;
+
+  // Source: grid layout generated with https://cssgrid-generator.netlify.app/
   return (
     <div
+      className={styles.dockedEbikeRouteOptionDetails}
       style={{
-        marginTop: "16px",
-        borderTop: "1px solid #ccc",
-        paddingTop: "16px",
         display: "grid",
-        gridTemplateColumns: "1fr 1fr 1fr 1fr",
-        gridGap: "16px",
+        padding: "0.15rem 0 0.25rem 0.33rem",
+        gridTemplateColumns: "0.90fr 0.65fr 0.5fr 0.8fr",
+        gridTemplateRows: "repeat(2, 1fr)",
+        gridColumnGap: "0px",
+        gridRowGap: "0.33em",
       }}
     >
-      {/* Column 1 */}
-      <div style={{ display: "flex", flexDirection: "column" }}>
-        <div>
-          <div>Departure and arrival times</div>
-          <div>{`${formatTimestamp(leaveAt)} – ${formatTimestamp(arriveAt)}`}</div>
-        </div>
-        <div
-          style={{
-            marginTop: "8px",
-            display: "flex",
-            alignItems: "center",
-          }}
-        >
-          <div style={{ display: "flex", alignItems: "center" }}>
-            <div style={{ textAlign: "center" }}>
-              <div>🧍</div>
-              <div>
-                {formatDurationToHumanReadableWithMinutePrecision(
-                  walkingTimeFromStartingPoint,
-                )}
-              </div>
-            </div>
-            <div style={{ margin: "0 8px" }}>{">"}</div>
-            <div style={{ textAlign: "center" }}>
-              <div>🚴</div>
-              <div>
-                {formatDurationToHumanReadableWithMinutePrecision(
-                  cyclingTimeStationToStation,
-                )}
-              </div>
-            </div>
-            <div style={{ margin: "0 8px" }}>{">"}</div>
-            <div style={{ textAlign: "center" }}>
-              <div>🧍</div>
-              <div>
-                {formatDurationToHumanReadableWithMinutePrecision(
-                  walkingTimeToDestination,
-                )}
-              </div>
+      {/* Column 0 */}
+      <div style={{ gridArea: "1 / 1 / 2 / 2" }}>
+        <div className={styles.label}>Departure and arrival times</div>
+        <div><strong>{`${formatTimestamp(leaveAt)} – ${formatTimestamp(arriveAt)}`}</strong></div>
+      </div>
+      <div style={{ gridArea: "2 / 1 / 3 / 2", paddingLeft: "1rem", marginTop: "-0.05rem" }}>
+        <div style={{ display: "flex", alignItems: "center" }}>
+          <div style={{ textAlign: "center" }}>
+            <div>🧍</div>
+            <div className={styles.smallLabel}>
+              {formatDurationToHumanReadableWithMinutePrecision(
+                walkingTimeFromStartingPoint,
+              )}
             </div>
           </div>
+          <div>{">"}</div>
+          <div style={{ textAlign: "center" }}>
+            <div>🚴</div>
+            <div className={styles.smallLabel}>
+              {formatDurationToHumanReadableWithMinutePrecision(
+                cyclingTimeStationToStation,
+              )}
+            </div>
+          </div>
+          <div>{">"}</div>
+          <div style={{ textAlign: "center" }}>
+            <div>🧍</div>
+            <div className={styles.smallLabel}>
+              {formatDurationToHumanReadableWithMinutePrecision(
+                walkingTimeToDestination,
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Column 1 */}
+      <div style={{ gridArea: "1 / 2 / 2 / 3", textAlign: "center" }}>
+        <div className={styles.label}>Total travel time</div>
+        <div>
+          <strong>
+            {formatDurationToHumanReadableWithMinutePrecision(travelTimeTotal)}
+          </strong>
         </div>
       </div>
 
       {/* Column 2 */}
-      <div>
-        <div>
-          <div>Total travel time</div>
-          <div>
-            {formatDurationToHumanReadableWithMinutePrecision(travelTimeTotal)}
-          </div>
-        </div>
+      <div style={{ gridArea: "1 / 3 / 2 / 4", textAlign: "center" }}>
+        <div className={styles.label}>Take bike at</div>
+        <div><strong>{formatTimestamp(takeBikeAt)}</strong></div>
       </div>
 
-      {/* Column 3 */}
-      <div style={{ display: "flex", flexDirection: "column" }}>
-        <div>
-          <div>Take bike at</div>
-          <div>{formatTimestamp(takeBikeAt)}</div>
-        </div>
-        <div style={{ marginTop: "8px" }}>
-          <div>Park bike at</div>
-          <div>{formatTimestamp(parkBikeAt)}</div>
-        </div>
+      <div style={{ gridArea: "2 / 3 / 3 / 4", textAlign: "center" }}>
+        <div className={styles.label}>Park bike at</div>
+        <div><strong>{formatTimestamp(parkBikeAt)}</strong></div>
       </div>
 
       {/* Column 4 */}
-      <div style={{ display: "flex", flexDirection: "column" }}>
-        <UsualAvailabilityDetails
-          label="(e-)bikes"
-          // NOTE: We are showing the availability of ALL bikes, not only e-bikes.
-          // This effectively converts the DockedEbikeRouteOption in a hybrid (standard/e-) route option.
-          // This is OK with regard to the UI because at no point do we mention that it is e-bikes only.
-          // We should refactor this code at some point and build in a proper way to handle bikes vs e-bikes.
-          n={
-            usualAvailabilityAtBikePickupStation
-              ? usualAvailabilityAtBikePickupStation.standardBikes +
-                usualAvailabilityAtBikePickupStation.electricBikes
-              : 0
-          }
-          availability={usualAvailabilityAtBikePickupStation}
-        />
-        <UsualAvailabilityDetails
-          label="empty docks"
-          n={
-            usualAvailabilityAtBikeDropOffStation
-              ? usualAvailabilityAtBikeDropOffStation.emptyDocks
-              : 0
-          }
-          availability={usualAvailabilityAtBikeDropOffStation}
-        />
-      </div>
+      <UsualAvailabilityDetails
+        label="(e-)bikes"
+        // NOTE: We are showing the availability of ALL bikes, not only e-bikes.
+        // This effectively converts the DockedEbikeRouteOption in a hybrid (standard/e-) route option.
+        // This is OK with regard to the UI because at no point do we mention that it is e-bikes only.
+        // We should refactor this code at some point and build in a proper way to handle bikes vs e-bikes.
+        n={
+          usualAvailabilityAtBikePickupStation
+            ? usualAvailabilityAtBikePickupStation.standardBikes +
+              usualAvailabilityAtBikePickupStation.electricBikes
+            : 0
+        }
+        availability={usualAvailabilityAtBikePickupStation}
+        style={{ gridArea: "1 / 4 / 2 / 5", textAlign: "center" }}
+      />
+      <UsualAvailabilityDetails
+        label="empty docks"
+        n={
+          usualAvailabilityAtBikeDropOffStation
+            ? usualAvailabilityAtBikeDropOffStation.emptyDocks
+            : 0
+        }
+        availability={usualAvailabilityAtBikeDropOffStation}
+        style={{ gridArea: "2 / 4 / 3 / 5", textAlign: "center" }}
+      />
     </div>
   );
 }
@@ -147,10 +142,10 @@ DockedEbikeRouteOptionDetails.propTypes = {
   }).isRequired,
 };
 
-function UsualAvailabilityDetails({ n, label, availability }) {
+function UsualAvailabilityDetails({ n, label, availability, style }) {
   return (
-    <div style={{ marginTop: "8px" }}>
-      <div>Usual availability</div>
+    <div style={style}>
+      <div className={styles.label}>Usual availability</div>
       {availability && availability.totalDocks > 0 ? (
         <div>
           {`${n} / ${availability.totalDocks} ${label} `}

--- a/src/pages/plan-a-trip.js
+++ b/src/pages/plan-a-trip.js
@@ -41,7 +41,7 @@ export default function PlanATripPage() {
 
   return (
     <main style={{ height: "100vh" }}>
-      <aside style={{ width: "600px", float: "left" }}>
+      <aside style={{ width: "575px", float: "left" }}>
         <RouteInputForm
           startingPointValue={startingPoint}
           onStartingPointChange={(location) => {
@@ -59,6 +59,7 @@ export default function PlanATripPage() {
             dispatch(arriveByDateTimeChanged(dateTime));
           }}
           orientation="column"
+          styleOverrides={{ marginBottom: "1rem" }}
         />
         {(() => {
           switch (loadingStatus) {


### PR DESCRIPTION
# Changelist
- Fix grid layout (now we're using 'real' grid, leveraging grid spacing, per-'cell' margins not necessary anymore)
- Adjust column sizes according to the content of each column
- Shrink sidebar - with improved space usage, we can slightly shrink the sidebar again
- Make travel times bold, following original prototype design
- Stretch inputs a bit to make room for the values contained

# Screenshot
![image](https://github.com/user-attachments/assets/0323dced-fcd2-4993-90a6-a2f4057d1eaa)
