### PR TITLE
MC-61: Fix 'Lets go!' button placement

### DIFF
--- a/src/components/RouteInputForm/RouteInputForm.jsx
+++ b/src/components/RouteInputForm/RouteInputForm.jsx
@@ -14,6 +14,14 @@ const RouteInputForm = ({
   styleOverrides = undefined,
 }) => {
 
+  const formStyle = {
+    display: "flex",
+    gap: "0.5rem",
+    alignItems: "stretch",
+    flexDirection: orientation,
+    padding: orientation === "column" ? "0.5rem" : 0,
+  };
+
   const inputStyle = orientation === "column" ? {
     width: "100%",
     boxSizing: "border-box",
@@ -22,11 +30,7 @@ const RouteInputForm = ({
   return (
     <form
       style={{
-        display: "flex",
-        alignItems: "stretch",
-        flexDirection: orientation,
-        gap: "0.5rem",
-        padding: "0.5rem",
+        ...formStyle,
         ...(styleOverrides || {}),
       }}
     >

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -45,6 +45,7 @@ const IndexPage = () => {
           display: "flex",
           flexDirection: "row",
           alignItems: "flex-end",
+          padding: "0.5rem",
         }}
       >
         <RouteInputForm


### PR DESCRIPTION
https://github.com/Micro-Commute/micro-commute-ui/pull/43 accidentally broke the 'Let's go' button placement. 

See 
![image](https://github.com/user-attachments/assets/67b97de4-eabc-4d1c-a32d-5636a8f6c1d5)

This pull request fixes that